### PR TITLE
Setup Farcaster AI twin mini-app repository

### DIFF
--- a/packages/openai-client/package.json
+++ b/packages/openai-client/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@ai-twin/openai-client",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Thin wrapper around OpenAI for style-mimic prompts",
+  "main": "dist/index.js",
+  "module": "esm/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "openai": "^4.28.4"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "@types/node": "^22.10.2",
+    "@farcaster/tsconfig": "workspace:*"
+  }
+}

--- a/packages/openai-client/src/index.ts
+++ b/packages/openai-client/src/index.ts
@@ -1,0 +1,48 @@
+import OpenAI from 'openai'
+
+export interface StyleMimicOptions {
+  username: string
+  sampleCasts: string[]
+  targetCast: string
+}
+
+/**
+ * Generates a reply imitating the user's public style.
+ * Returns at most 140 characters to remain native to Warpcast.
+ */
+export async function generateStyleMimicReply(
+  opts: StyleMimicOptions,
+  apiKey: string,
+): Promise<string> {
+  const openai = new OpenAI({ apiKey })
+  const examples = opts.sampleCasts.slice(0, 5).join('\n')
+
+  const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
+    {
+      role: 'system',
+      content: `You are the AI twin of ${opts.username}.`,
+    },
+    {
+      role: 'system',
+      content:
+        'Guidelines: keep the voice, brevity, emojis, inside jokes. Respond in <=140 characters.',
+    },
+    {
+      role: 'system',
+      content: `Examples:\n${examples}`,
+    },
+    {
+      role: 'user',
+      content: `Reply to: ${opts.targetCast}`,
+    },
+  ]
+
+  const completion = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    messages,
+    max_tokens: 80,
+    temperature: 0.7,
+  })
+
+  return completion.choices[0]?.message.content?.trim() ?? ''
+}

--- a/packages/openai-client/tsconfig.json
+++ b/packages/openai-client/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@farcaster/tsconfig/node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "target": "es2022"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/worker-api/package.json
+++ b/packages/worker-api/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@ai-twin/worker-api",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Cloudflare Worker backend for AI Twin Farcaster mini-app",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy --minify",
+    "build": "tsc",
+    "cf-typegen": "wrangler types --env-interface CloudflareBindings"
+  },
+  "dependencies": {
+    "hono": "^4.7.11",
+    "@farcaster/quick-auth": "^0.1.0",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "wrangler": "^4.4.0",
+    "typescript": "^5.3.3",
+    "@types/node": "^22.10.2",
+    "@farcaster/tsconfig": "workspace:*"
+  }
+}

--- a/packages/worker-api/src/index.ts
+++ b/packages/worker-api/src/index.ts
@@ -1,0 +1,97 @@
+import { createClient, Errors } from '@farcaster/quick-auth'
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+import { createMiddleware } from 'hono/factory'
+import { HTTPException } from 'hono/http-exception'
+import type { ExportedHandlerScheduledHandler } from '@cloudflare/workers-types'
+
+// ---- Types -----------------------------------------------------------------
+
+interface Env {
+  HOSTNAME: string
+  SUPABASE_URL: string
+  SUPABASE_ANON_KEY: string
+  // Add more bindings (KV / D1 / etc.) as you introduce them
+}
+
+interface User {
+  fid: number
+  primaryAddress?: string
+}
+
+// ---- Setup -----------------------------------------------------------------
+
+const quickAuth = createClient()
+const app = new Hono<{ Bindings: Env; Variables: { user: User } }>()
+
+const quickAuthMiddleware = createMiddleware<{
+  Bindings: Env
+  Variables: { user: User }
+}>(async (c, next) => {
+  const authorization = c.req.header('Authorization')
+  if (!authorization || !authorization.startsWith('Bearer ')) {
+    throw new HTTPException(401, { message: 'Missing token' })
+  }
+
+  try {
+    const payload = await quickAuth.verifyJwt({
+      token: authorization.split(' ')[1] as string,
+      domain: c.env.HOSTNAME,
+    })
+
+    // TODO: Replace with Supabase lookup for persisted profile settings
+    c.set('user', { fid: payload.sub })
+  } catch (e) {
+    if (e instanceof Errors.InvalidTokenError) {
+      throw new HTTPException(401, { message: 'Invalid token' })
+    }
+
+    throw e
+  }
+
+  await next()
+})
+
+// ---- Routes ----------------------------------------------------------------
+
+app.use('*', cors())
+
+// 1. Session probe
+app.get('/me', quickAuthMiddleware, (c) => {
+  return c.json(c.get('user'))
+})
+
+// 2. Bot settings (tone, frequency, targets)
+app.get('/settings', quickAuthMiddleware, async (c) => {
+  // TODO: pull from Supabase row keyed by fid
+  return c.json({ tone: 'default' })
+})
+
+app.post('/settings', quickAuthMiddleware, async (c) => {
+  // TODO: upsert into Supabase
+  const body = await c.req.json<{ tone: string }>()
+  return c.json({ ok: true, tone: body.tone })
+})
+
+// 3. Kick-off flow – mint managed signer via Neynar & persist
+app.post('/kickoff', quickAuthMiddleware, async (c) => {
+  // TODO: integrate Neynar managed signer util
+  return c.json({ ok: true })
+})
+
+// ---- Cron job --------------------------------------------------------------
+// The Worker Cron trigger will call this handler directly (no HTTP request)
+export const scheduled: ExportedHandlerScheduledHandler<Env> = async (
+  controller,
+  env,
+  ctx,
+) => {
+  // TODO: 1. fetch recent casts 2. build prompt 3. generate reply 4. post via signer
+  console.log('Cron fired at', controller.scheduledTime)
+}
+
+// ---- 404 -------------------------------------------------------------------
+
+app.all('*', (c) => c.text('Not found', 404))
+
+export default app

--- a/packages/worker-api/src/utils/managedSigner.ts
+++ b/packages/worker-api/src/utils/managedSigner.ts
@@ -1,0 +1,15 @@
+/*
+ * Placeholder utility for creating / retrieving a managed signer via Neynar.
+ * The actual logic will be copied from Neynar examples and adapted.
+ */
+
+export interface ManagedSigner {
+  signer_uuid: string
+  signer_public_key: string
+}
+
+export async function ensureManagedSigner(fid: number, neynarApiKey: string): Promise<ManagedSigner> {
+  // TODO: Implement using Neynar "managed-signers" endpoint.
+  // Docs: https://docs.neynar.com/reference/#managed-signer
+  throw new Error('Not implemented')
+}

--- a/packages/worker-api/src/utils/managedSigner.ts
+++ b/packages/worker-api/src/utils/managedSigner.ts
@@ -8,8 +8,43 @@ export interface ManagedSigner {
   signer_public_key: string
 }
 
-export async function ensureManagedSigner(fid: number, neynarApiKey: string): Promise<ManagedSigner> {
-  // TODO: Implement using Neynar "managed-signers" endpoint.
-  // Docs: https://docs.neynar.com/reference/#managed-signer
-  throw new Error('Not implemented')
+const NEYNAR_API_BASE = 'https://api.neynar.com/v2/farcaster'
+
+export async function ensureManagedSigner(
+  fid: number,
+  apiKey: string,
+): Promise<ManagedSigner> {
+  // 1. Check if signer already exists for this fid
+  const lookupRes = await fetch(
+    `${NEYNAR_API_BASE}/user/signer?fid=${fid}`,
+    {
+      headers: {
+        accept: 'application/json',
+        api_key: apiKey,
+      } as Record<string, string>,
+    },
+  )
+
+  if (lookupRes.ok) {
+    const data = (await lookupRes.json()) as ManagedSigner & {
+      error?: string
+    }
+    if (!data.error && data.signer_uuid) return data
+  }
+
+  // 2. Create a new managed signer
+  const resp = await fetch(`${NEYNAR_API_BASE}/user/signer`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      api_key: apiKey,
+    } as Record<string, string>,
+    body: JSON.stringify({ fid }),
+  })
+
+  if (!resp.ok) {
+    throw new Error(`Failed to create signer: ${resp.status} ${resp.statusText}`)
+  }
+
+  return (await resp.json()) as ManagedSigner
 }

--- a/packages/worker-api/tsconfig.json
+++ b/packages/worker-api/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@farcaster/tsconfig/node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "target": "es2022",
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/worker-api/wrangler.toml
+++ b/packages/worker-api/wrangler.toml
@@ -7,3 +7,7 @@ command = "pnpm --filter @ai-twin/worker-api run build"
 
 [vars]
 HOSTNAME = "ai-twin-worker.dev"
+NEYNAR_API_KEY = "<set-in-dashboard>"
+
+[triggers]
+crons = ["*/30 * * * *"]

--- a/packages/worker-api/wrangler.toml
+++ b/packages/worker-api/wrangler.toml
@@ -1,0 +1,9 @@
+name = "ai-twin-worker-api"
+main = "dist/index.js"
+compatibility_date = "2025-01-01"
+
+[build]
+command = "pnpm --filter @ai-twin/worker-api run build"
+
+[vars]
+HOSTNAME = "ai-twin-worker.dev"


### PR DESCRIPTION
Scaffold the `worker-api` Cloudflare Worker package to establish the backend foundation for the AI Twin Farcaster mini-app.

This PR sets up the basic directory structure, `package.json`, `wrangler.toml`, `tsconfig.json`, and an `index.ts` with stubbed routes (`/me`, `/settings`, `/kickoff`) and a cron handler. It includes a placeholder for the Neynar managed signer utility and integrates Quick-Auth JWT middleware, fulfilling the initial setup requirements for the backend.

---
<a href="https://cursor.com/background-agent?bcId=bc-87609423-b928-4b01-9382-28482432ca52">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-87609423-b928-4b01-9382-28482432ca52">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>